### PR TITLE
Upgrade micropromise to ~0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "deferred": "~0.6.6",
     "async": "~0.2.9",
     "co": "~1.4.0",
-    "micropromise": "~0.3.0"
+    "micropromise": "~0.4.0"
   },
   "devDependencies": {
     "noisyo": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "deferred": "~0.6.6",
     "async": "~0.2.9",
     "co": "~1.4.0",
-    "micropromise": "~0.4.0"
+    "micropromise": "~0.4.0",
+    "slowises": "git://github.com/rla/slowises.git"
   },
   "devDependencies": {
     "noisyo": "~0.1.1",

--- a/scenarios/light-serial/index.js
+++ b/scenarios/light-serial/index.js
@@ -13,6 +13,7 @@ function run(noise, bench) {
   bench('Pinky', require('./pinky')(dirname, noise))
   bench('Pinky (synchronous)', require('./pinky-sync')(dirname, noise))
   bench('Q', require('./q')(dirname, noise))
+  bench('Slowises', require('./slowises')(dirname, noise))
   bench('When', require('./when')(dirname, noise))
   bench('Deferred', require('./deferred')(dirname, noise))
   bench('microPromise', require('./micropromise')(dirname, noise))

--- a/scenarios/light-serial/slowises.js
+++ b/scenarios/light-serial/slowises.js
@@ -1,0 +1,11 @@
+var slowises = require('slowises')
+var listTest = require('./promises')(function(f) {
+                                       var d = slowises.deferred()
+                                       f(d.resolve, d.reject)
+                                       return d.promise })
+
+module.exports = function(path, noiseFactor) { return function(deferred) {
+  return listTest(path, noiseFactor)
+           .then(function(v){
+                   deferred.resolve() })
+}}

--- a/scenarios/parallel/index.js
+++ b/scenarios/parallel/index.js
@@ -29,6 +29,7 @@ function run(dupFactor, bench) {
   bench('Pinky', require('./pinky')(xs))
   bench('Pinky (synchronous)', require('./pinky-sync')(xs))
   bench('Q', require('./q')(xs))
+  bench('Slowises', require('./slowises')(xs))
   bench('When', require('./when')(xs))
   bench('Deferred', require('./deferred')(xs))
   bench('microPromise', require('./micropromise')(xs)) 

--- a/scenarios/parallel/slowises.js
+++ b/scenarios/parallel/slowises.js
@@ -1,0 +1,11 @@
+var slowises = require('slowises')
+var listTest = require('./promises')(function(f) {
+                                       var d = slowises.deferred()
+                                       f(d.resolve, d.reject)
+                                       return d.promise })
+
+module.exports = function(path, noiseFactor) { return function(deferred) {
+  return listTest(path, noiseFactor)
+           .then(function(v){
+                   deferred.resolve() })
+}}

--- a/scenarios/serial/index.js
+++ b/scenarios/serial/index.js
@@ -13,6 +13,7 @@ function run(noise, bench) {
   bench('Pinky', require('./pinky')(dirname, noise))
   bench('Pinky (synchronous)', require('./pinky-sync')(dirname, noise))
   bench('Q', require('./q')(dirname, noise))
+  bench('Slowises', require('./slowises')(dirname, noise))
   bench('When', require('./when')(dirname, noise))
   bench('Deferred', require('./deferred')(dirname, noise))
   bench('microPromise', require('./micropromise')(dirname, noise))

--- a/scenarios/serial/slowises.js
+++ b/scenarios/serial/slowises.js
@@ -1,0 +1,11 @@
+var slowises = require('slowises')
+var listTest = require('./promises')(function(f) {
+                                       var d = slowises.deferred()
+                                       f(d.resolve, d.reject)
+                                       return d.promise })
+
+module.exports = function(path, noiseFactor) { return function(deferred) {
+  return listTest(path, noiseFactor)
+           .then(function(v){
+                   deferred.resolve() })
+}}


### PR DESCRIPTION
With micropromises ~0.3.0 I get an error when running the suite:

```
/home/raivo/Downloads/promises-benchmark/node_modules/micropromise/index.js:215
        if(!this._state){
                ^
TypeError: Cannot read property '_state' of undefined
```

After upgrading to ~0.4.0 (0.4.6 to be exact), this error went away.
